### PR TITLE
Set up Vite tooling for portfolio development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Personal Portfolio
+
+This repository contains a simple static site served by Caddy inside Docker.
+
+## Development setup
+
+1. **Install Docker** and the Docker Compose plugin.
+2. **Start the dev server**:
+   ```sh
+   docker compose -f deploy/docker-compose.dev.yml up --build
+   ```
+   - Builds the Caddy image defined in `docker/Dockerfile`.
+   - Serves the files in `app/` on [http://localhost:3000](http://localhost:3000).
+   - Automatically reloads when you edit files under `app/`.
+3. **Stop the server** with `Ctrl+C` and clean up containers:
+   ```sh
+   docker compose -f deploy/docker-compose.dev.yml down
+   ```
+

--- a/app/index.html
+++ b/app/index.html
@@ -9,5 +9,6 @@
   <body>
     <h1>Hello from dev 🚀</h1>
     <p>If you’re reading this locally, Step 1 worked.</p>
+    <script type="module" src="/main.js"></script>
   </body>
 </html>

--- a/app/main.js
+++ b/app/main.js
@@ -1,0 +1,3 @@
+const app = document.createElement('p');
+app.textContent = 'Vite is configured and ready to go.';
+document.body.appendChild(app);

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -1,9 +1,9 @@
 services:
   web:
-    image: caddy:alpine
+    image: node:20-alpine
+    working_dir: /app
     ports:
-      - "3000:80"          # visit http://localhost:3000
+      - "3000:5173"          # visit http://localhost:3000
     volumes:
-      - ./app:/srv:ro      # hot-edit local files
-      - ./docker/Caddyfile.dev:/etc/caddy/Caddyfile:ro
-    restart: unless-stopped
+      - .:/app
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,13 @@
-# docker/Dockerfile
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY app ./app
+COPY vite.config.js ./
+RUN npm run build
+
+# Serve stage
 FROM caddy:alpine
-
-# Copy the Caddy config into the standard path
 COPY docker/Caddyfile.prod /etc/caddy/Caddyfile
-
-# Copy your static site into the container
-COPY app /srv
+COPY --from=build /app/dist /srv

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "albear-t",
+  "version": "1.0.0",
+  "description": "Personal portfolio site.",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: 'app',
+  build: {
+    outDir: '../dist',
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add Node-based tooling with Vite for local development
- switch dev compose to a Node container running the Vite dev server
- build static assets in the Dockerfile before serving with Caddy

## Testing
- `npm run build` *(fails: vite: not found)*
- `docker compose -f deploy/docker-compose.dev.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a8746f288331a875db7914806985